### PR TITLE
Feat/add onboardings index

### DIFF
--- a/app/controllers/onboardings_controller.rb
+++ b/app/controllers/onboardings_controller.rb
@@ -9,6 +9,11 @@ class OnboardingsController < ApplicationController
     @onboardings = current_user.onboardings.includes(:account)
   end
 
+  def create
+    onboarding = OnboardingProcess.add_new_onboarding_to(current_user)
+    select_plan_onboarding_path(onboarding)
+  end
+
   def continue
     redirect_to path_by_step(onboarding.current_step)
   end

--- a/app/models/onboarding.rb
+++ b/app/models/onboarding.rb
@@ -5,4 +5,8 @@ class Onboarding < ApplicationRecord
 
   belongs_to :owner, class_name: 'User'
   belongs_to :account
+
+  def pending?
+    status == 'in_progress'
+  end
 end

--- a/app/models/plan.rb
+++ b/app/models/plan.rb
@@ -2,6 +2,7 @@ class Plan < ApplicationRecord
   validates :name, presence: true
   validates :price, presence: true
   validates :status, presence: true
+  validates :icon_path, presence: true
 
   belongs_to :payment_recurrence
 

--- a/app/views/onboardings/index.html.erb
+++ b/app/views/onboardings/index.html.erb
@@ -1,14 +1,20 @@
-<div class="flex flex-col align-between justify-between min-h-full">
-  <div class="flex flex-col">
-    onboading#index
+<div class="flex flex-col align-between justify-between h-full">
+  <h3 class="mb-4 text-xl font-bold">Onboardings:</h3>
 
+  <div class="flex flex-col gap-2 overflow-y-scroll h-full py-2">
     <% @onboardings.each do |onboarding| %>
-      <span class="block"><%= onboarding.account.name %></span> 
-      <%= link_to "Some Page", continue_onboarding_path(onboarding) %>
+      <%= render partial: 'partials/onboarding_account_card', locals: { onboarding: onboarding } %>
     <% end %>
   </div>
 
-  <div>
-    <%= link_to "Sign-out", destroy_user_session_path, data: { turbo_method: :delete } %>
-  </div>
+  <%=
+    link_to(
+      '+',
+      onboardings_path,
+      data: { turbo_method: :post },
+      class: 'flex border-dashed border-2 border-purple px-4 py-6 rounded-md mt-6'
+    )
+  %>
+
+  <%= link_to "Sign-out", destroy_user_session_path, data: { turbo_method: :delete }, class: 'blue-link' %>
 </div>

--- a/app/views/partials/_onboarding_account_card.html.erb
+++ b/app/views/partials/_onboarding_account_card.html.erb
@@ -1,0 +1,11 @@
+<div class="flex justify-between border border-purple px-4 py-6 rounded-md">
+  <div class="flex flex-col">
+    <span class="text-base">account: <%= onboarding.account.name %></span>
+    <span class="text-sm">onboarding status: <%= onboarding.status.gsub('_', ' ') %></span>
+  </div>
+  <div>
+    <% if onboarding.pending? %>
+      <%= link_to('continue onboarding', continue_onboarding_path(onboarding), class: 'blue-link text-sm p-0') %>
+    <% end %>
+  </div>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -8,7 +8,7 @@ Rails.application.routes.draw do
   # Defines the root path route ("/")
   root 'onboardings#index'
 
-  resources :onboardings, only: %i[index show] do
+  resources :onboardings, only: %i[index show create] do
     get :continue, on: :member
     get :select_plan, on: :member
   end

--- a/db/migrate/20230511223838_add_column_to_plans.rb
+++ b/db/migrate/20230511223838_add_column_to_plans.rb
@@ -1,0 +1,5 @@
+class AddColumnToPlans < ActiveRecord::Migration[7.0]
+  def change
+    add_column :plans, :icon_path, :string, null: false, default: ''
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_05_11_221558) do
+ActiveRecord::Schema[7.0].define(version: 2023_05_11_223838) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -75,6 +75,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_05_11_221558) do
     t.bigint "payment_recurrence_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "icon_path", default: "", null: false
     t.index ["payment_recurrence_id"], name: "index_plans_on_payment_recurrence_id"
   end
 

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -6,51 +6,69 @@
 #   movies = Movie.create([{ name: "Star Wars" }, { name: "Lord of the Rings" }])
 #   Character.create(name: "Luke", movie: movies.first)
 
+PaymentRecurrence.destroy_all
+Plan.destroy_all
 
-Plan.create(
-  name: 'Arcade',
-  frequence_number: 1,
-  frequence_unit: 'mo',
-  price: 9.00,
-  note: nil
+payment_recurrence = PaymentRecurrence.create(
+  name: 'monthly',
+  days_delta: 0,
+  months_delta: 1,
+  years_delta: 0,
+  acronym: 'mo'
 )
 
 Plan.create(
   name: 'Arcade',
-  frequence_number: 1,
-  frequence_unit: 'yr',
+  price: 9.00,
+  note: nil,
+  status: 'active',
+  payment_recurrence:
+)
+
+Plan.create(
+  name: 'Advanced',
+  price: 12.00,
+  note: nil,
+  status: 'active',
+  payment_recurrence:
+)
+
+Plan.create(
+  name: 'Pro',
+  price: 15.00,
+  note: nil,
+  status: 'active',
+  payment_recurrence:
+)
+
+payment_recurrence = PaymentRecurrence.create(
+  name: 'yearly',
+  days_delta: 0,
+  months_delta: 0,
+  years_delta: 1,
+  acronym: 'yr'
+)
+
+Plan.create(
+  name: 'Arcade',
   price: 90.00,
   note: '2 months free',
+  status: 'active',
+  payment_recurrence:
 )
 
 Plan.create(
   name: 'Advanced',
-  frequence_number: 1,
-  frequence_unit: 'mo',
-  price: 12.00,
-  note: nil
-)
-
-Plan.create(
-  name: 'Advanced',
-  frequence_number: 1,
-  frequence_unit: 'yr',
   price: 120.00,
   note: '2 months free',
+  status: 'active',
+  payment_recurrence:
 )
 
 Plan.create(
   name: 'Pro',
-  frequence_number: 1,
-  frequence_unit: 'mo',
-  price: 15.00,
-  note: nil
-)
-
-Plan.create(
-  name: 'Pro',
-  frequence_number: 1,
-  frequence_unit: 'yr',
   price: 150.00,
   note: '2 months free',
+  status: 'active',
+  payment_recurrence:
 )

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -6,8 +6,8 @@
 #   movies = Movie.create([{ name: "Star Wars" }, { name: "Lord of the Rings" }])
 #   Character.create(name: "Luke", movie: movies.first)
 
-PaymentRecurrence.destroy_all
 Plan.destroy_all
+PaymentRecurrence.destroy_all
 
 payment_recurrence = PaymentRecurrence.create(
   name: 'monthly',
@@ -18,6 +18,7 @@ payment_recurrence = PaymentRecurrence.create(
 )
 
 Plan.create(
+  icon_path: '/1rXqk06/arcade-plan-icon.png',
   name: 'Arcade',
   price: 9.00,
   note: nil,
@@ -26,6 +27,7 @@ Plan.create(
 )
 
 Plan.create(
+  icon_path: '/MspwF5X/advanced-plan-icon.png',
   name: 'Advanced',
   price: 12.00,
   note: nil,
@@ -34,6 +36,7 @@ Plan.create(
 )
 
 Plan.create(
+  icon_path: '/nDGT4xW/pro-plan-icon.png',
   name: 'Pro',
   price: 15.00,
   note: nil,
@@ -50,6 +53,7 @@ payment_recurrence = PaymentRecurrence.create(
 )
 
 Plan.create(
+  icon_path: '/1rXqk06/arcade-plan-icon.png',
   name: 'Arcade',
   price: 90.00,
   note: '2 months free',
@@ -58,6 +62,7 @@ Plan.create(
 )
 
 Plan.create(
+  icon_path: '/MspwF5X/advanced-plan-icon.png',
   name: 'Advanced',
   price: 120.00,
   note: '2 months free',
@@ -66,6 +71,7 @@ Plan.create(
 )
 
 Plan.create(
+  icon_path: '/nDGT4xW/pro-plan-icon.png',
   name: 'Pro',
   price: 150.00,
   note: '2 months free',

--- a/spec/factories/plan.rb
+++ b/spec/factories/plan.rb
@@ -4,6 +4,7 @@ FactoryBot.define do
     price { Faker::Number.between(from: 10.0, to: 120.0) }
     status { %w[active inactive].sample }
     note { Faker::Lorem.sentence }
+    icon_path { Faker::Internet.url }
 
     association :payment_recurrence
   end

--- a/spec/models/onboarding_spec.rb
+++ b/spec/models/onboarding_spec.rb
@@ -14,4 +14,22 @@ RSpec.describe Onboarding, type: :model do
     it { is_expected.to belong_to(:account) }
     it { is_expected.to belong_to(:owner).class_name('User') }
   end
+
+  describe '#pending?' do
+    describe 'when status is in_progress' do
+      before { onboarding.status = 'in_progress' }
+
+      it 'returns true' do
+        expect(onboarding.pending?).to be true
+      end
+    end
+
+    describe 'when status is completed' do
+      before { onboarding.status = 'completed' }
+
+      it 'returns false' do
+        expect(onboarding.pending?).to be false
+      end
+    end
+  end
 end

--- a/spec/models/plan_spec.rb
+++ b/spec/models/plan_spec.rb
@@ -7,6 +7,7 @@ RSpec.describe Plan, type: :model do
     it { is_expected.to validate_presence_of(:name) }
     it { is_expected.to validate_presence_of(:price) }
     it { is_expected.to validate_presence_of(:status) }
+    it { is_expected.to validate_presence_of(:icon_path) }
   end
 
   describe 'associations' do


### PR DESCRIPTION
when a user comes back to conitnue an onboarding, he can sign in
<img width="996" alt="image" src="https://github.com/ImMPrada/multi-step-form-FM/assets/26731448/0d93be2d-8daf-405c-a8a4-c1c0fe1df124">

This PR shows an index of onboardings before that
<img width="1717" alt="image" src="https://github.com/ImMPrada/multi-step-form-FM/assets/26731448/ffa9a017-2ebb-4022-9289-fba3500a720c">

so the user can select which account onboarding continue, or add a new onboarding
<img width="862" alt="image" src="https://github.com/ImMPrada/multi-step-form-FM/assets/26731448/ab1318d7-5803-4645-b169-0c013e249b34">
